### PR TITLE
Detach charge embedding for torchscript export

### DIFF
--- a/altimeter/model.py
+++ b/altimeter/model.py
@@ -462,8 +462,9 @@ class FlipyFlopy(nn.Module):
         elif len(inpch.shape) == 2:
             inpch = inpch.squeeze(1)
             
+        ce_feat = self.embedCE(inpch, self.cesz, 10.0).detach()
         ch_embed = nn.functional.silu(
-            self.denseCH(self.embedCE(inpch, self.cesz, 10.0))
+            self.denseCH(ce_feat)
         )
         embed = self.postcat(torch.cat([ch_embed],-1))
         


### PR DESCRIPTION
## Summary
- Detach charge embedding features before feeding them into the dense layer to prevent torchscript from treating gradient-carrying constants as constants
- Run export in evaluation mode with `torch.no_grad()` and detach knot inputs for ONNX export

## Testing
- `python -m py_compile Altimeter/altimeter/model.py Altimeter/altimeter/export.py`

------
https://chatgpt.com/codex/tasks/task_e_689958678ee48325b62633a124d72db3